### PR TITLE
add redirect to reports/ before throwing 404:

### DIFF
--- a/app.js
+++ b/app.js
@@ -70,6 +70,13 @@ app.use('/', routes);
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 
+//Shiny apps are proxied at /reports, so attempt to redirect before throwing 404
+app.use(function(req, res, next) {
+  res.redirect('/reports' + req.url);
+  next();
+
+})
+
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {
   var err = new Error('Not Found');


### PR DESCRIPTION
### Description

Added a middleware method to the app to redirect the user to `/reports/` before throwing a 404 error. The default setup for Shiny server installations is for a server to host a directory of apps - so that navigating to "example.com/appName" would take you to the app in the folder appName, and this pull request is an attempt to replicate that. 

### References
Fix based on issue discussed in #20. 

Note - this is a quick fix that I'm using on my own deployment of this app. I do wonder if long-term it might be better to not do a redirect at all, but instead to proxy the shiny apps directly on the root (while leaving the 'auth' endpoints (login, logout, callback) for the authentication system to handle). I think this would be a cleaner experience for the users, but that would involve more complex changes to this app and so might not be worth it. 

If this is something that you're working on or aiming to resolve another way, please feel free to reject this PR! 

Best,
Dave


